### PR TITLE
Enable CSRF protection and include tokens

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -102,7 +102,7 @@ define('APP_CHARSET',$config['charset']);
 | setting this variable to TRUE (boolean).  See the user guide for details.
 |
 */
-$config['enable_hooks'] = FALSE;
+$config['enable_hooks'] = TRUE;
 
 /*
 |--------------------------------------------------------------------------
@@ -452,7 +452,7 @@ $config['global_xss_filtering'] = TRUE;
 | 'csrf_regenerate' = Regenerate token on every submission
 | 'csrf_exclude_uris' = Array of URIs which ignore CSRF checks
 */
-$config['csrf_protection'] = FALSE;
+$config['csrf_protection'] = TRUE;
 $config['csrf_token_name'] = 'csrf_test_name';
 $config['csrf_cookie_name'] = 'csrf_cookie_name';
 $config['csrf_expire'] = 7200;

--- a/application/config/hooks.php
+++ b/application/config/hooks.php
@@ -11,3 +11,10 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 |	https://codeigniter.com/user_guide/general/hooks.html
 |
 */
+
+$hook['pre_system'][] = array(
+    'class'    => 'CsrfHook',
+    'function' => 'add_token_from_header',
+    'filename' => 'CsrfHook.php',
+    'filepath' => 'hooks'
+);

--- a/application/hooks/CsrfHook.php
+++ b/application/hooks/CsrfHook.php
@@ -1,0 +1,19 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class CsrfHook {
+    /**
+     * Allow AJAX requests to send the CSRF token via header.
+     * Moves X-CSRF-TOKEN header into \$_POST so CI's native
+     * CSRF protection can validate it automatically.
+     */
+    public function add_token_from_header()
+    {
+        $tokenName = config_item('csrf_token_name');
+        $headerToken = isset($_SERVER['HTTP_X_CSRF_TOKEN']) ? $_SERVER['HTTP_X_CSRF_TOKEN'] : null;
+        if ($headerToken && empty($_POST[$tokenName])) {
+            $_POST[$tokenName] = $headerToken;
+        }
+    }
+}
+

--- a/application/views/config/acoes.php
+++ b/application/views/config/acoes.php
@@ -1,20 +1,23 @@
 <div class="col-md-4 col-lg-3">
-	<form action="/transacoes/sincronizar" method="post">
-		<div class="input-group mb-3">
-			<span class="input-group-text" />Dias</span> <input type="number" value="7" name="dias" class="form-control">
-			<button type="submit" class="btn btn-primary">Sincronizar Transações Recentes</button>
-		</div>
-	</form>
-	
-	<form action="/transacoes/sincronizaTransacoesVencidas" method="post">
-		<div class="input-group mb-3">
-			<button type="submit" class="btn btn-primary">Sincronizar Transações Vencidas</button>
-		</div>
-	</form>
+        <form action="/transacoes/sincronizar" method="post">
+                <input type="hidden" name="<?=$this->security->get_csrf_token_name();?>" value="<?=$this->security->get_csrf_hash();?>">
+                <div class="input-group mb-3">
+                        <span class="input-group-text" />Dias</span> <input type="number" value="7" name="dias" class="form-control">
+                        <button type="submit" class="btn btn-primary">Sincronizar Transações Recentes</button>
+                </div>
+        </form>
 
-	<form action="/inscricoes/totalizar" method="post">
-		<div class="input-group mb-3">
-			<button type="submit" class="btn btn-primary">Totalizar Inscrições de Grupos Ativos</button>
-		</div>
-	</form>
+        <form action="/transacoes/sincronizaTransacoesVencidas" method="post">
+                <input type="hidden" name="<?=$this->security->get_csrf_token_name();?>" value="<?=$this->security->get_csrf_hash();?>">
+                <div class="input-group mb-3">
+                        <button type="submit" class="btn btn-primary">Sincronizar Transações Vencidas</button>
+                </div>
+        </form>
+
+        <form action="/inscricoes/totalizar" method="post">
+                <input type="hidden" name="<?=$this->security->get_csrf_token_name();?>" value="<?=$this->security->get_csrf_hash();?>">
+                <div class="input-group mb-3">
+                        <button type="submit" class="btn btn-primary">Totalizar Inscrições de Grupos Ativos</button>
+                </div>
+        </form>
 </div>

--- a/application/views/header.php
+++ b/application/views/header.php
@@ -10,6 +10,15 @@
 <title><?php isset($title)?$title:'CANNAL Produções'?></title>
     <?php $this->assets->print_view_head()?>
     <?php $this->assets->renderInline();?>
+<script>
+var csrf_token_name = '<?=$this->security->get_csrf_token_name();?>';
+var csrf_token = '<?=$this->security->get_csrf_hash();?>';
+if(window.jQuery){
+    var csrfData = {};
+    csrfData[csrf_token_name] = csrf_token;
+    $.ajaxSetup({data: csrfData});
+}
+</script>
 <?php if(@$closeHead !== false):?>
 </head>
 <?php endif;?>

--- a/application/views/inscricao/modal_whatsAppMsg.php
+++ b/application/views/inscricao/modal_whatsAppMsg.php
@@ -22,8 +22,9 @@ $tags = array_keys($ci->inscricoes_model->getInscricaoCompleta(3));
 				</button>
 			</div>
 			<div class="modal-body">
-				<form>
-					<?php foreach ($msg as $m){?>
+                                <form>
+                                        <input type="hidden" name="<?=$ci->security->get_csrf_token_name();?>" value="<?=$ci->security->get_csrf_hash();?>">
+                                        <?php foreach ($msg as $m){?>
 					<div class="form-group input-group mb-2">
 						<textarea class="form-control form-control-sm" disabled="disabled" readonly="readonly"><?php echo $m?></textarea>
 						<button type="button" class="btn btn-primary btn-lg btn-block whatsAppMsg" data-msg="<?php echo $m?>">Selecionar</button>

--- a/application/views/login/login.php
+++ b/application/views/login/login.php
@@ -3,8 +3,9 @@ defined('BASEPATH') or exit('No direct script access allowed');
 $this->load->view('header');?>
 <body class="d-flex align-items-center py-4 bg-body-tertiary text-center">
 	<main class="form-signin w-100 m-auto">
-    	<form class="auth">
-    		<?php
+        <form class="auth">
+                <input type="hidden" name="<?=$this->security->get_csrf_token_name();?>" value="<?=$this->security->get_csrf_hash();?>" id="csrf_token">
+                <?php
             $alerts_out = '';
             $alerts = $this->session->flashdata('alerts');
             $this->session->unset_userdata('alerts');

--- a/application/views/transacoes/modal_estornos.php
+++ b/application/views/transacoes/modal_estornos.php
@@ -10,8 +10,9 @@ if (isset($this->result_list)) {
 				<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
 			</div>
 			<div class="modal-body">
-				<form class="form-horizontal">
-					<div class="form-group form-material form-group">
+                                <form class="form-horizontal">
+                                        <input type="hidden" name="<?=$this->security->get_csrf_token_name();?>" value="<?=$this->security->get_csrf_hash();?>">
+                                        <div class="form-group form-material form-group">
 						<input type="text" class="form-control" value="R$ <?php echo number_format($row['operadoras_transacoes.otr_valorBruto'],2,',','.')?>" id="otr_valorCancelamento_<?php echo $row['primary_key']?>" data-type="price" data-reverse="true" value="" data-mask="#.###.##0,00" prefix="" separator="." point="," maxlength="10" decimals="2" autocomplete="off">
 					</div>
 				</form>

--- a/assets/js/login.js
+++ b/assets/js/login.js
@@ -9,15 +9,17 @@ var Login = {
 			if (user == "" || pass == "") {
 				alertify.alert('Atenção','Preencha usuário e senha, por favor.', 'warning');
 			} else {
-				$.ajax({
-					url: "/login/auth",
-					data: {
-						user: user,
-						pass: pass
-					},
-					type: "POST",
-					dataType: 'json',
-					success: function(data, status, jqXHR) {
+                                var requestData = {
+                                                user: user,
+                                                pass: pass
+                                };
+                                requestData[csrf_token_name] = csrf_token;
+                                $.ajax({
+                                        url: "/login/auth",
+                                        data: requestData,
+                                        type: "POST",
+                                        dataType: 'json',
+                                        success: function(data, status, jqXHR) {
 						if (data.status == "error" && typeof data.error !== "undefined" && data.error) {
 							alertify.alert(data.error);
 						} else if (data.status == "success" && typeof data.redirect !== "undefined" && data.redirect) {


### PR DESCRIPTION
## Summary
- enable CodeIgniter hooks and CSRF protection
- add hidden CSRF tokens to forms and AJAX requests
- add hook to accept CSRF token from headers

## Testing
- `php -l application/config/config.php`
- `php -l application/config/hooks.php`
- `php -l application/views/login/login.php`
- `php -l application/views/inscricao/modal_whatsAppMsg.php`
- `php -l application/views/config/acoes.php`
- `php -l application/views/transacoes/modal_estornos.php`
- `php -l application/views/header.php`
- `php -l application/hooks/CsrfHook.php`
- `node --check assets/js/login.js`


------
https://chatgpt.com/codex/tasks/task_e_68a787bb9a70832a8b1ab0cff38aa94b