### PR TITLE
chore: secure cookies from JavaScript access

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -408,7 +408,7 @@ $config['cookie_prefix']	= '';
 $config['cookie_domain']	= 'inscricoes.cannal.com.br';
 $config['cookie_path']		= '/';
 $config['cookie_secure']	= TRUE;
-$config['cookie_httponly'] 	= FALSE;
+$config['cookie_httponly']      = TRUE;
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- set `cookie_httponly` configuration to `TRUE`
- verified no JavaScript dependencies rely on reading server cookies

## Testing
- `php -l application/config/config.php`
- `composer test` *(fails: Command "test" is not defined.)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a787c0bbd8832ab48f72220715a3a0