### PR TITLE
Centraliza rehash de senhas no Config

### DIFF
--- a/application/controllers/Config.php
+++ b/application/controllers/Config.php
@@ -2,40 +2,64 @@
 
 class Config extends SYS_Controller
 {
-
-    public $submenu = [
+    /**
+     * Itens do submenu de configurações
+     */
+    public array $submenu = [
         'config/acoes' => 'Ações',
         'config/operadoras' => 'Operadoras',
-        'config/taxas' => 'Taxas'
+        'config/taxas' => 'Taxas',
+        'config/senha' => 'Senha'
     ];
 
-    function __construct()
+    public function __construct()
     {
         parent::__construct();
         $this->checkLogin();
+        $this->load->model('usuarios_model');
     }
 
-    public function index()
-    {
-        redirect('/config/acoes');
-    }
-    
-    public function acoes()
-    {
-        return $this->_view($this->load->view('config/acoes.php', $this->vars, true));
-    }
-    
-    public function taxas()
-    {
-        redirect('/config/acoes');
-    }
-    
-    public function operadoras()
+    public function index(): void
     {
         redirect('/config/acoes');
     }
 
-    public function _view($conteudo)
+    public function acoes(): void
+    {
+        $conteudo = $this->load->view('config/acoes.php', $this->vars, true);
+        $this->_view($conteudo);
+    }
+
+    public function taxas(): void
+    {
+        redirect('/config/acoes');
+    }
+
+    public function operadoras(): void
+    {
+        redirect('/config/acoes');
+    }
+
+    /**
+     * Tela de manutenção de senhas
+     */
+    public function senha(): void
+    {
+        $conteudo = $this->load->view('config/senha.php', $this->vars, true);
+        $this->_view($conteudo);
+    }
+
+    /**
+     * Re-hash de senhas legadas para o padrão atual
+     */
+    public function rehash_senhas(): void
+    {
+        $total = $this->usuarios_model->rehashSenhasAntigas();
+        $_SESSION['alert_success'][] = $total . ' senhas atualizadas.';
+        redirect('/config/senha');
+    }
+
+    private function _view(string $conteudo): void
     {
         $this->vars['submenu'] = $this->submenu;
         $this->vars['conteudo'] = $conteudo;

--- a/application/views/config/senha.php
+++ b/application/views/config/senha.php
@@ -1,0 +1,6 @@
+<div class="col-md-4 col-lg-3">
+    <p>Atualize os hashes de senhas antigos para o padrão atual.</p>
+    <form action="/config/rehash_senhas" method="post" onsubmit="return confirm('Atualizar todas as senhas?');">
+        <button type="submit" class="btn btn-warning">Reprocessar senhas</button>
+    </form>
+</div>


### PR DESCRIPTION
## Resumo
- adiciona ação no Config para reprocessar senhas legadas
- rehash automático ao autenticar usuários com hash antigo
- remove formulário de troca de senha e validações associadas

## Testes
- `php -l application/controllers/Config.php`
- `php -l application/config/form_validation.php`
- `php -l application/models/Usuarios_model.php`
- `php -l application/views/config/senha.php`


------
https://chatgpt.com/codex/tasks/task_e_68a787c6c2a4832a9bc10166b2d532e3