### PR TITLE
Add development-only production DB import

### DIFF
--- a/application/config/database.php
+++ b/application/config/database.php
@@ -97,12 +97,26 @@ $db['development'] = array(
 
 $db['production'] = $db['development'];
 $db['production'] = array_merge($db['production'],array(
-		'hostname' => 'localhost',
-		'username' => 'cannal_inscricoe',
-		'password' => 'YnGF5O.jQE~W',
-		'database' => 'cannal_inscricoes',
+                'hostname' => 'localhost',
+                'username' => 'cannal_inscricoe',
+                'password' => 'YnGF5O.jQE~W',
+                'database' => 'cannal_inscricoes',
         'db_debug' => false
 ));
+
+// Ajusta conexão via túnel SSH em ambiente de desenvolvimento
+if (ENVIRONMENT === 'development') {
+    $db['production'] = array_merge($db['production'], [
+        'hostname' => getenv('PROD_SSH_LOCAL_HOST') ?: '127.0.0.1',
+        'port'     => getenv('PROD_SSH_LOCAL_PORT') ?: 3307,
+        'ssh_host' => getenv('PROD_SSH_HOST'),
+        'ssh_port' => getenv('PROD_SSH_PORT') ?: 22,
+        'ssh_user' => getenv('PROD_SSH_USER'),
+        'ssh_key'  => getenv('PROD_SSH_KEY'),
+        'ssh_remote_host' => getenv('PROD_SSH_REMOTE_HOST') ?: '127.0.0.1',
+        'ssh_remote_port' => getenv('PROD_SSH_REMOTE_PORT') ?: 3306,
+    ]);
+}
 
 
 define('APP_DBHOST', $db[$active_group]['hostname']);

--- a/application/controllers/Config.php
+++ b/application/controllers/Config.php
@@ -41,6 +41,82 @@ class Config extends SYS_Controller
     }
 
     /**
+     * Importa o banco de produção para desenvolvimento.
+     *
+     * Abre túnel SSH, gera dump e importa no banco de desenvolvimento.
+     *
+     * @return void
+     */
+    public function importDatabase(): void
+    {
+        // Garante execução apenas em desenvolvimento
+        if (ENVIRONMENT !== 'development') {
+            show_404();
+        }
+
+        // Carrega configurações dos bancos
+        $this->config->load('database', true);
+        $prod = $this->config->item('production', 'database');
+        $dev  = $this->config->item('development', 'database');
+
+        // Define nome e caminho do arquivo de dump
+        $fileName = date('Y.m.d-H.i-') . $prod['database'] . '.sql';
+        $filePath = FCPATH . 'sql/' . $fileName;
+
+        // Abre túnel SSH para o banco de produção
+        $sshCmd = sprintf(
+            'ssh -i %s -p %s -L %s:%s:%s %s -N >/dev/null 2>&1 & echo $!',
+            escapeshellarg($prod['ssh_key']),
+            escapeshellarg($prod['ssh_port']),
+            escapeshellarg($prod['port']),
+            escapeshellarg($prod['ssh_remote_host']),
+            escapeshellarg($prod['ssh_remote_port']),
+            escapeshellarg($prod['ssh_user'] . '@' . $prod['ssh_host'])
+        );
+        $tunnelPid = trim(shell_exec($sshCmd));
+
+        // Caso o túnel não seja estabelecido, aborta
+        if ($tunnelPid === '') {
+            $_SESSION['alert_error'][] = 'Falha ao estabelecer túnel SSH.';
+            redirect('/config/acoes');
+            return;
+        }
+
+        // Aguarda estabilização do túnel
+        sleep(1);
+
+        // Realiza dump do banco de produção através do túnel
+        $dumpCmd = sprintf(
+            'mysqldump -h%s -P%s -u%s --password=%s %s > %s',
+            escapeshellarg($prod['hostname']),
+            escapeshellarg($prod['port']),
+            escapeshellarg($prod['username']),
+            escapeshellarg($prod['password']),
+            escapeshellarg($prod['database']),
+            escapeshellarg($filePath)
+        );
+        exec($dumpCmd);
+
+        // Encerra túnel SSH
+        exec('kill ' . escapeshellarg($tunnelPid) . ' 2>/dev/null');
+
+        // Importa dump no banco de desenvolvimento
+        $importCmd = sprintf(
+            'mysql -h%s -u%s --password=%s %s < %s',
+            escapeshellarg($dev['hostname']),
+            escapeshellarg($dev['username']),
+            escapeshellarg($dev['password']),
+            escapeshellarg($dev['database']),
+            escapeshellarg($filePath)
+        );
+        exec($importCmd);
+
+        // Informa sucesso e retorna à tela de ações
+        $_SESSION['alert_success'][] = 'Banco de produção importado.';
+        redirect('/config/acoes');
+    }
+
+    /**
      * Tela de manutenção de senhas
      */
     public function senha(): void

--- a/application/views/config/acoes.php
+++ b/application/views/config/acoes.php
@@ -20,4 +20,13 @@
                         <button type="submit" class="btn btn-primary">Totalizar Inscrições de Grupos Ativos</button>
                 </div>
         </form>
+
+        <?php if (ENVIRONMENT === 'development'): ?>
+        <form action="/config/importDatabase" method="post">
+                <input type="hidden" name="<?=$this->security->get_csrf_token_name();?>" value="<?=$this->security->get_csrf_hash();?>">
+                <div class="input-group mb-3">
+                        <button type="submit" class="btn btn-danger">Importar Banco de Produção</button>
+                </div>
+        </form>
+        <?php endif; ?>
 </div>


### PR DESCRIPTION
## Summary
- allow devs to import production DB via config actions
- configure production DB access via SSH tunnel in development
- open SSH tunnel to dump production DB and import into development
- source remote host and port for tunnel from database config

## Testing
- `composer validate --no-check-all`
- `php -l application/config/database.php`
- `php -l application/controllers/Config.php`
- `php -l application/views/config/acoes.php`


------
https://chatgpt.com/codex/tasks/task_e_68b08375f488832ab602762d7ac981e5