### PR TITLE
Adicionar visualização de logs no Config

### DIFF
--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -56,5 +56,7 @@ $route['inscricao/(:any)'] = 'inscricoes/inscricao/$1';
 $route['inscricao/(:any)/(:any)'] = 'inscricoes/inscricao/$1/$2';
 $route['presenca'] = 'alunos/presenca';
 $route['sair'] = 'login/sair';
+// Rota para exibição de arquivos de log
+$route['config/show_log/(.+)'] = 'config/show_log/$1';
 $route['404_override'] = '';
 $route['translate_uri_dashes'] = FALSE;

--- a/application/controllers/Config.php
+++ b/application/controllers/Config.php
@@ -41,6 +41,31 @@ class Config extends SYS_Controller
     }
 
     /**
+     * Exibe o conteúdo de um arquivo de log.
+     *
+     * @param string|null $path Caminho relativo do arquivo de log.
+     * @return void
+     */
+    public function show_log(?string $path = null): void
+    {
+        if ($path === null) {
+            show_404();
+        }
+
+        $logsDir = APPPATH . 'logs' . DIRECTORY_SEPARATOR;
+        $realLogsDir = realpath($logsDir);
+        $fullPath = realpath($logsDir . $path);
+
+        if ($realLogsDir === false || $fullPath === false || strpos($fullPath, $realLogsDir) !== 0 || !is_file($fullPath)) {
+            show_404();
+        }
+
+        $this->load->helper('file');
+        header('Content-Type: text/plain; charset=utf-8');
+        echo read_file($fullPath);
+    }
+
+    /**
      * Importa o banco de produção para desenvolvimento.
      *
      * Abre túnel SSH, gera dump e importa no banco de desenvolvimento.


### PR DESCRIPTION
## Resumo
- exibir conteúdo de arquivos de log diretamente pelo controller Config
- incluir rota para acesso a logs via URL com segurança básica

## Testes
- `php -l application/controllers/Config.php`
- `php -l application/config/routes.php`
- `composer test` *(falha: Command "test" is not defined)*
- `./vendor/bin/phpunit` *(falha: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b48b481ca8832aad9b3be39f239e7a