### PR TITLE
Mover _Entity para core como SYS_Entity

### DIFF
--- a/application/core/SYS_Entity.php
+++ b/application/core/SYS_Entity.php
@@ -1,13 +1,13 @@
 <?php
-namespace CANNALInscricoes\Entities;
 
-class _Entity
+class SYS_Entity
 {
 
     /**
-     * Exporta as variáveis um array.
+     * Importa os valores do array para as propriedades da entidade.
      *
-     * @return array
+     * @param array $array Dados a serem importados
+     * @return self
      */
     public function importArray(array $array): self
     {
@@ -23,9 +23,10 @@ class _Entity
     /**
      * Exporta as variáveis um array.
      *
+     * @param bool $include_null Incluir valores nulos no resultado
      * @return array
      */
-    public function toArray($include_null = true): array
+    public function toArray(bool $include_null = true): array
     {
         $return = [];
         $reflect = new \ReflectionClass($this);
@@ -47,7 +48,14 @@ class _Entity
         return $return;
     }
 
-    public function import(self|array $obj, $include_null = false)
+    /**
+     * Importa os dados de outra entidade ou array.
+     *
+     * @param self|array $obj Objeto ou array de origem
+     * @param bool $include_null Incluir valores nulos na importação
+     * @return self
+     */
+    public function import(self|array $obj, bool $include_null = false): self
     {
         if (! is_array($obj)) {
             $obj = $obj->toArray($include_null);
@@ -57,5 +65,5 @@ class _Entity
     }
 }
 
-/* End of file _Entity.php */
-/* Location: ./applicaion/core/_Entity.php */
+/* End of file SYS_Entity.php */
+/* Location: ./application/core/SYS_Entity.php */

--- a/application/entities/AlunosCreditosEntity.php
+++ b/application/entities/AlunosCreditosEntity.php
@@ -1,7 +1,7 @@
 <?php
 namespace CANNALInscricoes\Entities;
 
-class AlunosCreditosEntity extends _Entity
+class AlunosCreditosEntity extends \SYS_Entity
 {
 
     protected string $table = 'alunos_creditos';

--- a/application/entities/AlunosEntity.php
+++ b/application/entities/AlunosEntity.php
@@ -1,7 +1,7 @@
 <?php
 namespace CANNALInscricoes\Entities;
 
-class AlunosEntity extends _Entity
+class AlunosEntity extends \SYS_Entity
 {
 
     protected string $table = 'alunos';

--- a/application/entities/FeriadosEntity.php
+++ b/application/entities/FeriadosEntity.php
@@ -1,7 +1,7 @@
 <?php
 namespace CANNALInscricoes\Entities;
 
-class FeriadosEntity extends _Entity
+class FeriadosEntity extends \SYS_Entity
 {
 
     protected string $table = 'feriados';

--- a/application/entities/GruposDatasEntity.php
+++ b/application/entities/GruposDatasEntity.php
@@ -1,7 +1,7 @@
 <?php
 namespace CANNALInscricoes\Entities;
 
-class GruposDatasEntity extends _Entity
+class GruposDatasEntity extends \SYS_Entity
 {
 
     protected $prefix = 'grd_';

--- a/application/entities/GruposDistribuicaoEntity.php
+++ b/application/entities/GruposDistribuicaoEntity.php
@@ -1,7 +1,7 @@
 <?php
 namespace CANNALInscricoes\Entities;
 
-class GruposDistribuicaoEntity extends _Entity
+class GruposDistribuicaoEntity extends \SYS_Entity
 {
 
     protected $prefix = 'dst_';

--- a/application/entities/GruposEntity.php
+++ b/application/entities/GruposEntity.php
@@ -1,7 +1,7 @@
 <?php
 namespace CANNALInscricoes\Entities;
 
-class GruposEntity extends _Entity
+class GruposEntity extends \SYS_Entity
 {
 
     protected string $table = 'grupos';

--- a/application/entities/GruposFormasEntity.php
+++ b/application/entities/GruposFormasEntity.php
@@ -1,7 +1,7 @@
 <?php
 namespace CANNALInscricoes\Entities;
 
-class GruposFormasEntity extends _Entity
+class GruposFormasEntity extends \SYS_Entity
 {
 
     protected $prefix = 'gfp_';

--- a/application/entities/InscricoesEntity.php
+++ b/application/entities/InscricoesEntity.php
@@ -1,7 +1,7 @@
 <?php
 namespace CANNALInscricoes\Entities;
 
-class InscricoesEntity extends _Entity
+class InscricoesEntity extends \SYS_Entity
 {
 
     protected string $table = 'inscricoes';

--- a/application/entities/OperadorasEntity.php
+++ b/application/entities/OperadorasEntity.php
@@ -1,7 +1,7 @@
 <?php
 namespace CANNALInscricoes\Entities;
 
-class OperadorasEntity extends _Entity
+class OperadorasEntity extends \SYS_Entity
 {
 
     protected string $prefix = 'opr_';

--- a/application/entities/OperadorasFormasEntity.php
+++ b/application/entities/OperadorasFormasEntity.php
@@ -1,7 +1,7 @@
 <?php
 namespace CANNALInscricoes\Entities;
 
-class OperadorasFormasEntity extends _Entity
+class OperadorasFormasEntity extends \SYS_Entity
 {
 
     protected $prefix = 'ofo_';

--- a/application/entities/OperadorasTransacoesEntity.php
+++ b/application/entities/OperadorasTransacoesEntity.php
@@ -1,7 +1,7 @@
 <?php
 namespace CANNALInscricoes\Entities;
 
-class OperadorasTransacoesEntity extends _Entity
+class OperadorasTransacoesEntity extends \SYS_Entity
 {
 
     protected $table = 'operadoras_transacoes';

--- a/application/entities/PresencaEntity.php
+++ b/application/entities/PresencaEntity.php
@@ -1,7 +1,7 @@
 <?php
 namespace CANNALInscricoes\Entities;
 
-class PresencaEntity extends _Entity
+class PresencaEntity extends \SYS_Entity
 {
 
     protected $prefix = 'prs_';

--- a/application/entities/RecebiveisEntity.php
+++ b/application/entities/RecebiveisEntity.php
@@ -1,7 +1,7 @@
 <?php
 namespace CANNALInscricoes\Entities;
 
-class RecebiveisEntity extends _Entity
+class RecebiveisEntity extends \SYS_Entity
 {
 
     protected $prefix = 'rec_';

--- a/application/entities/RecebiveisEstornosEntity.php
+++ b/application/entities/RecebiveisEstornosEntity.php
@@ -1,7 +1,7 @@
 <?php
 namespace CANNALInscricoes\Entities;
 
-class RecebiveisEstornosEntity extends _Entity
+class RecebiveisEstornosEntity extends \SYS_Entity
 {
 
     protected $prefix = 'res_';

--- a/application/entities/RecebiveisRepassesEntity.php
+++ b/application/entities/RecebiveisRepassesEntity.php
@@ -1,7 +1,7 @@
 <?php
 namespace CANNALInscricoes\Entities;
 
-class RecebiveisRepassesEntity extends _Entity
+class RecebiveisRepassesEntity extends \SYS_Entity
 {
 
     protected string $prefix = 'rre_';

--- a/application/entities/RepassesEntity.php
+++ b/application/entities/RepassesEntity.php
@@ -1,7 +1,7 @@
 <?php
 namespace CANNALInscricoes\Entities;
 
-class RepassesEntity extends _Entity
+class RepassesEntity extends \SYS_Entity
 {
 
     protected $prefix = 'rep_';

--- a/application/entities/UsuariosEntity.php
+++ b/application/entities/UsuariosEntity.php
@@ -1,7 +1,7 @@
 <?php
 namespace CANNALInscricoes\Entities;
 
-class UsuariosEntity extends _Entity
+class UsuariosEntity extends \SYS_Entity
 {
 
     protected string $prefix = 'usr_';


### PR DESCRIPTION
## Descrição
- mover classe base de entidades para `application/core` como `SYS_Entity`
- ajustar entidades para estender `\SYS_Entity`

## Testes
- `php -l application/core/SYS_Entity.php`
- `for f in application/entities/*Entity.php; do php -l "$f"; done`
- `composer install --no-interaction` *(falhou: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b495954cd4832ab2bcf97b0ee3222a