### PR TITLE
Registrar última notificação de inscrição

### DIFF
--- a/application/entities/InscricoesEntity.php
+++ b/application/entities/InscricoesEntity.php
@@ -40,6 +40,10 @@ class InscricoesEntity extends \SYS_Entity
 
     protected ?int $user = null;
 
+    protected ?string $notificacaoAluno = null;
+
+    protected ?string $notificacaoCoordenadores = null;
+
     /**
      * Get the value of id
      */
@@ -311,6 +315,50 @@ class InscricoesEntity extends \SYS_Entity
     public function setUser(?int $user): self
     {
         $this->user = $user;
+        return $this;
+    }
+
+    /**
+     * Obtém a data da última notificação enviada ao aluno.
+     *
+     * @return string|null
+     */
+    public function getStudentNotification(): ?string
+    {
+        return $this->notificacaoAluno;
+    }
+
+    /**
+     * Define a data da última notificação enviada ao aluno.
+     *
+     * @param string|null $notificacaoAluno
+     * @return self
+     */
+    public function setStudentNotification(?string $notificacaoAluno): self
+    {
+        $this->notificacaoAluno = $notificacaoAluno;
+        return $this;
+    }
+
+    /**
+     * Obtém a data da última notificação enviada aos coordenadores.
+     *
+     * @return string|null
+     */
+    public function getCoordinatorsNotification(): ?string
+    {
+        return $this->notificacaoCoordenadores;
+    }
+
+    /**
+     * Define a data da última notificação enviada aos coordenadores.
+     *
+     * @param string|null $notificacaoCoordenadores
+     * @return self
+     */
+    public function setCoordinatorsNotification(?string $notificacaoCoordenadores): self
+    {
+        $this->notificacaoCoordenadores = $notificacaoCoordenadores;
         return $this;
     }
 }

--- a/application/helpers/inscricoes_helper.php
+++ b/application/helpers/inscricoes_helper.php
@@ -202,7 +202,7 @@ if (! function_exists('reenviar_confirmacao')) {
         ]);
         if ($transacoes) {
             foreach ($transacoes as $transacao) {
-                if ($ci->inscricoes->email_inscricao($xcrud->get('primary'), 'pagamento_confirmado', $transacao)) {
+                if ($ci->inscricoes->email_inscricao($xcrud->get('primary'), 'pagamento_confirmado', $transacao, true)) {
                     $xcrud->set_notify('OTR ' . $transacao['otr_id'] . ': e-mail enviado', 'success', true);
                 } else {
                     $xcrud->set_notify('OTR ' . $transacao['otr_id'] . ': falha', 'error', true);

--- a/application/libraries/controllers/InscricoesLib.php
+++ b/application/libraries/controllers/InscricoesLib.php
@@ -274,7 +274,16 @@ class InscricoesLib
         return $this->CI->transacoes->sincronizar($transacao->getId(), null, false);
     }
 
-    public function email_inscricao($ins_id, $tipo, $transacao = null)
+    /**
+     * Envia notificações para o aluno ou coordenadores de acordo com o tipo.
+     *
+     * @param int        $ins_id      Identificador da inscrição
+     * @param string     $tipo        Tipo de notificação
+     * @param mixed|null $transacao   Dados da transação relacionada
+     * @param bool       $forceAluno  Força envio ao aluno quando o tipo é pagamento_confirmado
+     * @return bool|null Resultado do envio
+     */
+    public function email_inscricao($ins_id, $tipo, $transacao = null, bool $forceAluno = false)
     {
         $this->CI->initMail();
         $this->CI->load->model('inscricoes_model');
@@ -287,17 +296,17 @@ class InscricoesLib
             $transacao = new OperadorasTransacoesEntity($transacao);
         }
         $vars['transacao'] = $transacao;
+        $envio = false;
+
         if ($tipo == 'solicita_aprovacao') {
-            /* E-MAIL PARA O COORDERNADOR */
-            $destinatarios = array();
+            $destinatarios = [];
             foreach ($this->CI->grupos_model->getCoordenadoresDoGrupo($vars['ins']['ins_grupo']) as $row) {
-                if ($row['usr_recebeInscricoes'] == 1 && $row['usr_email'] != "") {
+                if ($row['usr_recebeInscricoes'] == 1 && $row['usr_email'] != '') {
                     $destinatarios[] = $row['usr_email'];
                 }
             }
             if (count($destinatarios)) {
                 $this->CI->logs->write('DEBUG', 'Enviar solicitação de aprovação');
-
                 foreach ($destinatarios as $d) {
                     $this->CI->mail->addAddress($d);
                 }
@@ -314,45 +323,58 @@ class InscricoesLib
                     $name = substr($name, 0, $pos) . $ext;
                 }
                 $this->CI->mail->attach($_SERVER['DOCUMENT_ROOT'] . '/writable/alunos/' . $vars['alu']['alu_cv']);
-                return $this->CI->mail->send();
+                $envio = $this->CI->mail->send();
+                return $envio;
             }
+            return false;
         } else if ($tipo == 'transacao_nao_aprovada') {
-            /* E-MAIL PARA O ALUNO */
             $this->CI->mail->addAddress($vars['alu']['alu_email']);
             $this->CI->mail->subject('[INSCRIÇÃO RECEBIDA] ' . $vars['grp']['grp_nomePublico']);
             $this->CI->mail->message($this->CI->load->view('emails/aluno/falhaCartao.php', $vars, true));
             return $this->CI->mail->send();
         } else if ($tipo == 'inscricao_aprovada') {
-            /* E-MAIL PARA O ALUNO */
             $this->CI->mail->addAddress($vars['alu']['alu_email']);
             $this->CI->mail->subject('[INSCRIÇÃO APROVADA] ' . $vars['grp']['grp_nomePublico']);
             $this->CI->mail->message($this->CI->load->view('emails/aluno/inscricaoAprovada.php', $vars, true));
             return $this->CI->mail->send();
         } else if ($tipo == 'pagamento_confirmado') {
-            /* E-MAIL PARA O ALUNO */
-            $this->CI->mail->addAddress($vars['alu']['alu_email']);
-            $this->CI->mail->subject('[INSCRIÇÃO APROVADA] ' . $vars['grp']['grp_nomePublico']);
-            $this->CI->mail->message($this->CI->load->view('emails/aluno/pagamentoConfirmado_' . $transacao->getTipo() . '.php', $vars, true));
-            $this->CI->mail->send();
-
-            /* E-MAIL PARA O COORDERNADOR */
-            $destinatarios = array();
-            foreach ($this->CI->grupos_model->getCoordenadoresDoGrupo($vars['ins']['ins_grupo']) as $row) {
-                if ($row['usr_recebeInscricoes'] == 1 && $row['usr_email'] != "") {
-                    $destinatarios[] = $row['usr_email'];
+            if ($forceAluno || empty($vars['ins']['ins_notificacaoAluno'])) {
+                $this->CI->mail->addAddress($vars['alu']['alu_email']);
+                $this->CI->mail->subject('[INSCRIÇÃO APROVADA] ' . $vars['grp']['grp_nomePublico']);
+                $this->CI->mail->message($this->CI->load->view('emails/aluno/pagamentoConfirmado_' . $transacao->getTipo() . '.php', $vars, true));
+                if ($this->CI->mail->send()) {
+                    $this->CI->alunos_model->updateInscricao($ins_id, [
+                        'ins_notificacaoAluno' => date('Y-m-d H:i:s')
+                    ]);
+                    $envio = true;
                 }
             }
-            if (count($destinatarios)) {
-                $vars['inscricoes'] = $this->CI->grupos_model->getAlunosInscritos($vars['grp']['grp_id']);
-                foreach ($destinatarios as $d) {
-                    $this->CI->mail->addAddress($d);
+            if (empty($vars['ins']['ins_notificacaoCoordenadores'])) {
+                $this->CI->initMail();
+                $destinatarios = [];
+                foreach ($this->CI->grupos_model->getCoordenadoresDoGrupo($vars['ins']['ins_grupo']) as $row) {
+                    if ($row['usr_recebeInscricoes'] == 1 && $row['usr_email'] != '') {
+                        $destinatarios[] = $row['usr_email'];
+                    }
                 }
-                $this->CI->mail->subject('[NOVA INSCRIÇÃO CONFIRMADA] ' . $vars['grp']['grp_nomePublico']);
-                $msg = $this->CI->load->view('emails/coordenador/novaInscricao.php', $vars, true);
-                $msg .= $this->CI->load->view('emails/coordenador/listaInscritos.php', $vars, true);
-                $this->CI->mail->message($msg);
-                return $this->CI->mail->send();
+                if (count($destinatarios)) {
+                    $vars['inscricoes'] = $this->CI->grupos_model->getAlunosInscritos($vars['grp']['grp_id']);
+                    foreach ($destinatarios as $d) {
+                        $this->CI->mail->addAddress($d);
+                    }
+                    $this->CI->mail->subject('[NOVA INSCRIÇÃO CONFIRMADA] ' . $vars['grp']['grp_nomePublico']);
+                    $msg = $this->CI->load->view('emails/coordenador/novaInscricao.php', $vars, true);
+                    $msg .= $this->CI->load->view('emails/coordenador/listaInscritos.php', $vars, true);
+                    $this->CI->mail->message($msg);
+                    if ($this->CI->mail->send()) {
+                        $this->CI->alunos_model->updateInscricao($ins_id, [
+                            'ins_notificacaoCoordenadores' => date('Y-m-d H:i:s')
+                        ]);
+                        $envio = true;
+                    }
+                }
             }
+            return $envio;
         } else if ($tipo == 'inscricao_recebida_processo') {
             $this->CI->mail->addAddress($vars['alu']['alu_email']);
             $this->CI->mail->subject('[INSCRIÇÃO RECEBIDA] ' . $vars['grp']['grp_nomePublico']);
@@ -373,9 +395,9 @@ class InscricoesLib
             $this->CI->mail->subject('[ESTORNO] ' . $vars['grp']['grp_nomePublico']);
             $this->CI->mail->message($this->CI->load->view('emails/aluno/confirmacaoEstorno.php', $vars, true));
             return $this->CI->mail->send();
-        } else {
-            return null;
         }
+
+        return null;
     }
 
     public function whatsAppMsg()

--- a/sql/v2.2-update
+++ b/sql/v2.2-update
@@ -1,0 +1,3 @@
+ALTER TABLE `inscricoes`
+  ADD `ins_notificacaoAluno` DATETIME NULL DEFAULT NULL AFTER `ins_user`,
+  ADD `ins_notificacaoCoordenadores` DATETIME NULL DEFAULT NULL AFTER `ins_notificacaoAluno`;


### PR DESCRIPTION
## Resumo
- Registrar data da última notificação para aluno e coordenadores nas inscrições
- Impedir reenvio automático de e-mails quando já notificado
- Forçar reenvio de confirmação ao aluno quando solicitado manualmente
- Restringir controle de notificação na biblioteca apenas ao tipo `pagamento_confirmado`

## Testes
- `php -l application/entities/InscricoesEntity.php`
- `php -l application/libraries/controllers/InscricoesLib.php`
- `php -l application/helpers/inscricoes_helper.php`


------
https://chatgpt.com/codex/tasks/task_e_68b60e136014832a9c0254f9e7664869