### PR TITLE
Substitui CANNALLogs por Monolog

### DIFF
--- a/application/controllers/Cron.php
+++ b/application/controllers/Cron.php
@@ -1,5 +1,5 @@
 <?php
-use CANNALLogs\Logs;
+use CANNALInscricoes\Libraries\Logs;
 use CANNALInscricoes\Entities\OperadorasEntity;
 use CANNALInscricoes\Entities\RecebiveisEntity;
 use CANNALInscricoes\Entities\OperadorasTransacoesEntity;
@@ -7,7 +7,12 @@ use CANNALInscricoes\Entities\OperadorasTransacoesEntity;
 class Cron extends SYS_Controller
 {
 
-    var $logs;
+    /**
+     * Instância do gerenciador de logs.
+     *
+     * @var Logs
+     */
+    private Logs $logs;
 
     function __construct()
     {

--- a/application/controllers/Teste.php
+++ b/application/controllers/Teste.php
@@ -4,7 +4,7 @@ use CANNALPagamentos\Entities\Cliente;
 use CANNALPagamentos\Entities\Cartao;
 use CANNALPagamentos\Entities\Pedido;
 use CANNALInscricoes\Entities\OperadorasEntity;
-use CANNALLogs\Logs;
+use CANNALInscricoes\Libraries\Logs;
 use CANNALInscricoes\Entities\AlunosCreditosEntity;
 
 class Teste extends SYS_Controller

--- a/application/core/SYS_Controller.php
+++ b/application/core/SYS_Controller.php
@@ -1,5 +1,5 @@
 <?php
-use CANNALLogs\Logs;
+use CANNALInscricoes\Libraries\Logs;
 use PHPMailer\PHPMailer\PHPMailer;
 
 defined('DIR_IMAGEM_USUARIOS') or define('DIR_IMAGEM_USUARIOS',  '/writable/usuarios/');
@@ -11,6 +11,13 @@ class SYS_Controller extends CI_Controller
 {
 
     public ?array $vars = [];
+
+    /**
+     * Instância principal do gerenciador de logs.
+     *
+     * @var Logs
+     */
+    protected Logs $logs;
 
     function __construct()
     {

--- a/application/core/SYS_Exceptions.php
+++ b/application/core/SYS_Exceptions.php
@@ -5,7 +5,7 @@
  * @package    CannalInscricoes
  */
 
-use CANNALLogs\Logs;
+use CANNALInscricoes\Libraries\Logs;
 
 /**
  * Class SYS_Exceptions

--- a/application/libraries/Logs.php
+++ b/application/libraries/Logs.php
@@ -1,0 +1,93 @@
+<?php
+namespace CANNALInscricoes\Libraries;
+
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use Monolog\Level;
+use Monolog\Formatter\LineFormatter;
+
+/**
+ * Gerencia registros de log utilizando o Monolog.
+ */
+class Logs
+{
+    /**
+     * Instância do logger.
+     *
+     * @var Logger
+     */
+    private Logger $logger;
+
+    /**
+     * Diretório onde os logs serão armazenados.
+     *
+     * @var string
+     */
+    private string $directory;
+
+    /**
+     * Nome base do arquivo de log.
+     *
+     * @var string
+     */
+    private string $logName;
+
+    /**
+     * Construtor.
+     *
+     * @param string $folder  Pasta dentro de application/logs.
+     * @param string $logName Nome base do arquivo de log.
+     */
+    public function __construct(string $folder = '', string $logName = '')
+    {
+        $base = rtrim(APPPATH . 'logs/', '/') . '/';
+        if ($folder !== '') {
+            $base .= trim($folder, '/') . '/';
+        }
+        if (! is_dir($base)) {
+            mkdir($base, 0777, true);
+        }
+        $this->directory = $base;
+        $this->logName = $logName !== '' ? $logName : date('Y-m-d');
+        $this->createLogger();
+    }
+
+    /**
+     * Define o nome do arquivo de log.
+     *
+     * @param string $logName Nome do arquivo de log.
+     *
+     * @return void
+     */
+    public function setLogName(string $logName): void
+    {
+        $this->logName = $logName;
+        $this->createLogger();
+    }
+
+    /**
+     * Escreve uma mensagem no log.
+     *
+     * @param string $level   Nível do log.
+     * @param string $message Mensagem a ser registrada.
+     *
+     * @return void
+     */
+    public function write(string $level, string $message): void
+    {
+        $this->logger->log(Level::fromName(strtoupper($level)), $message);
+    }
+
+    /**
+     * Cria a instância do logger com base no nome atual.
+     *
+     * @return void
+     */
+    private function createLogger(): void
+    {
+        $this->logger = new Logger('app');
+        $handler = new StreamHandler($this->directory . $this->logName . '.log', Level::Debug);
+        $handler->setFormatter(new LineFormatter(null, null, true, true));
+        $this->logger->setHandlers([$handler]);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,15 @@
 {
-	"name" : "ariellcannal/inscricoes",
-	"type" : "project",
-	"homepage" : "https://inscricoes.cannal.com.br",
-	"license" : "MIT",
+        "name" : "ariellcannal/inscricoes",
+        "type" : "project",
+        "description" : "Aplicação de inscrições com logging via Monolog",
+        "homepage" : "https://inscricoes.cannal.com.br",
+        "license" : "MIT",
 	"require" : {
 		"php" : ">=8.0.0",
 		"dompdf/dompdf" : "~2.0",
-		"phpmailer/phpmailer" : "~6.9",
-		"ariellcannal/pagamentos" : "master",
-		"ariellcannal/logs" : "master"
+                "phpmailer/phpmailer" : "~6.9",
+                "ariellcannal/pagamentos" : "master",
+                "monolog/monolog" : "^3.5"
 	},
 	"require-dev" : {
 		"phpseclib/phpseclib" : "~3.0"
@@ -17,20 +18,17 @@
 			"type" : "git",
 			"url" : "git@github.com:ariellcannal/pagamentos.git",
 			"name" : "pagamentos"
-		}, {
-			"type" : "git",
-			"url" : "git@github.com:ariellcannal/logs.git",
-			"name" : "logs"
-		}
-	],
+                }
+        ],
 	"autoload" : {
-		"psr-4" : {
-			"CANNALInscricoes\\Entities\\" : "application/entities/"
-		}
+                "psr-4" : {
+                "CANNALInscricoes\\Entities\\" : "application/entities/",
+                "CANNALInscricoes\\Libraries\\" : "application/libraries/"
+                }
 	},
 	"minimum-stability" : "dev",
 	"prefer-stable" : true,
-	"config" : {
-		"notify-on-install" : false
-	}
+        "config" : {
+                "notify-on-install" : false
+        }
 }


### PR DESCRIPTION
## Descrição
- remove dependência CANNALLogs e adiciona Monolog
- cria biblioteca de logs baseada no Monolog e ajusta controladores e núcleo
- ajusta namespace da biblioteca de logs e autoload para `CANNALInscricoes\Libraries`

## Testes
- `php -l application/libraries/Logs.php`
- `php -l application/controllers/Teste.php`
- `php -l application/controllers/Cron.php`
- `php -l application/core/SYS_Controller.php`
- `php -l application/core/SYS_Exceptions.php`
- `composer dump-autoload` *(falhou: Could not scan for classes inside vendor/dompdf/dompdf/lib)*
- `composer update --ignore-platform-reqs` *(falhou: solicita token GitHub para repositório privado)*
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_e_68b6fbb504f0832a8a4aeaa428272987