### PR TITLE
Remove biblioteca Logs e usa Monolog diretamente

### DIFF
--- a/application/controllers/Cron.php
+++ b/application/controllers/Cron.php
@@ -2,7 +2,7 @@
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\StreamHandler;
 use Monolog\Level;
-use Monolog\Logger;
+use Monolog\Logger; 
 use CANNALInscricoes\Entities\OperadorasEntity;
 use CANNALInscricoes\Entities\RecebiveisEntity;
 use CANNALInscricoes\Entities\OperadorasTransacoesEntity;

--- a/application/controllers/Cron.php
+++ b/application/controllers/Cron.php
@@ -1,13 +1,27 @@
 <?php
-use CANNALLogs\Logs;
+use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\Logger;
 use CANNALInscricoes\Entities\OperadorasEntity;
 use CANNALInscricoes\Entities\RecebiveisEntity;
 use CANNALInscricoes\Entities\OperadorasTransacoesEntity;
 
 class Cron extends SYS_Controller
 {
+    /**
+     * Instância do logger da classe.
+     *
+     * @var Logger
+     */
+    private Logger $logger;
 
-    var $logs;
+    /**
+     * Diretório base dos logs do cron.
+     *
+     * @var string
+     */
+    private string $logDirectory;
 
     function __construct()
     {
@@ -16,10 +30,21 @@ class Cron extends SYS_Controller
         if (! is_cli() && ENVIRONMENT != 'development') {
             show_404();
         }
-        $this->logs = new Logs('cron');
+        $this->logDirectory = APPPATH . 'logs/cron/';
+        if (! is_dir($this->logDirectory)) {
+            mkdir($this->logDirectory, 0777, true);
+        }
+        $this->logger = new Logger('cron');
     }
 
-    private function setLockFile($name)
+    /**
+     * Cria arquivo de lock para evitar execuções simultâneas.
+     *
+     * @param string $name Nome do processo.
+     *
+     * @return void
+     */
+    private function setLockFile(string $name): void
     {
         $lockFile = APPPATH . 'cache/cron_' . $name . '.lock';
 
@@ -27,7 +52,7 @@ class Cron extends SYS_Controller
         if (file_exists($lockFile)) {
             $lastModified = filemtime($lockFile);
             if ((time() - $lastModified) < 600) { // menos de 10 minutos
-                $this->logs->write('ERROR', $name . ' já está em execução.');
+                $this->logger->error($name . ' já está em execução.');
                 return;
             }
         }
@@ -35,7 +60,14 @@ class Cron extends SYS_Controller
         file_put_contents($lockFile, time());
     }
 
-    private function unsetLockFile($name)
+    /**
+     * Remove o arquivo de lock do processo.
+     *
+     * @param string $name Nome do processo.
+     *
+     * @return void
+     */
+    private function unsetLockFile(string $name): void
     {
         @unlink(APPPATH . 'cache/cron_' . $name . '.lock');
     }
@@ -44,82 +76,97 @@ class Cron extends SYS_Controller
      *
      * /usr/local/bin/php /home/grupotapa/public_html/grupos/index.php cron hora >> /home/grupotapa/public_html/grupos/application/logs/cron/cron-`date +\%Y-\%m-\%d`.log; echo "" >> /home/grupotapa/public_html/grupos/application/logs/cron/cron-`date +\%Y-\%m-\%d`.log
      */
-    function cincoMinutos()
+    function cincoMinutos(): void
     {
         $name = 'cincoMinutos';
-        $this->logs->setLogName($name . '-' . date('Y-m-d'));
+        $this->setLogFile($name . '-' . date('Y-m-d'));
         $this->setLockFile($name);
         try {
             $this->_atualizaTransacoesVencidas();
             $this->_atualizaTransacoesRecentes();
         } catch (Exception $e) {
-            $this->logs->write('ERROR', $name . ' - ' . $e->getMessage());
+            $this->logger->error($name . ' - ' . $e->getMessage());
         }
         $this->unsetLockFile($name);
     }
 
-    function hora()
+    function hora(): void
     {
         $name = 'hora';
-        $this->logs->setLogName($name . '-' . date('Y-m-d'));
+        $this->setLogFile($name . '-' . date('Y-m-d'));
         $this->setLockFile($name);
         try {} catch (Exception $e) {
-            $this->logs->write('ERROR', $name . ' - ' . $e->getMessage());
+            $this->logger->error($name . ' - ' . $e->getMessage());
         }
         $this->unsetLockFile($name);
     }
 
-    function dia()
+    function dia(): void
     {
         $name = 'dia';
-        $this->logs->setLogName($name . '-' . date('Y-m-d'));
+        $this->setLogFile($name . '-' . date('Y-m-d'));
         $this->setLockFile($name);
         try {
             $this->sincronizarPrevistosAteHoje();
         } catch (Exception $e) {
-            $this->logs->write('ERROR', $name . ' - ' . $e->getMessage());
+            $this->logger->error($name . ' - ' . $e->getMessage());
         }
         $this->unsetLockFile($name);
     }
 
-    function semana()
+    function semana(): void
     {
         $name = 'semana';
-        $this->logs->setLogName($name . '-' . date('Y-m-d'));
+        $this->setLogFile($name . '-' . date('Y-m-d'));
         $this->setLockFile($name);
         try {} catch (Exception $e) {
-            $this->logs->write('ERROR', $name . ' - ' . $e->getMessage());
+            $this->logger->error($name . ' - ' . $e->getMessage());
         }
         $this->unsetLockFile($name);
     }
 
-    function mes()
+    function mes(): void
     {
         $name = 'mes';
-        $this->logs->setLogName($name . '-' . date('Y-m-d'));
+        $this->setLogFile($name . '-' . date('Y-m-d'));
         $this->setLockFile($name);
         try {} catch (Exception $e) {
-            $this->logs->write('ERROR', $name . ' - ' . $e->getMessage());
+            $this->logger->error($name . ' - ' . $e->getMessage());
         }
         $this->unsetLockFile($name);
     }
 
-    function _atualizaTransacoesVencidas()
+    function _atualizaTransacoesVencidas(): void
     {
         $this->load->library('controllers/TransacoesLib', null, 'transacoes');
         $this->transacoes->sincronizaTransacoesVencidas();
     }
 
-    function _atualizaTransacoesRecentes()
+    function _atualizaTransacoesRecentes(): void
     {
         $this->load->library('controllers/TransacoesLib', null, 'transacoes');
         $this->transacoes->sincronizar(null, 2);
     }
 
-    function sincronizarPrevistosAteHoje()
+    function sincronizarPrevistosAteHoje(): void
     {
         $this->load->library('controllers/RecebiveisLib', null, 'recebiveis');
         $this->recebiveis->sincronizarPrevistosAteHoje();
+    }
+
+    /**
+     * Configura o arquivo de log para o processo atual.
+     *
+     * @param string $logName Nome do arquivo de log.
+     *
+     * @return void
+     */
+    private function setLogFile(string $logName): void
+    {
+        $path = $this->logDirectory . $logName . '.log';
+        $handler = new StreamHandler($path, Level::Debug);
+        $handler->setFormatter(new LineFormatter(null, null, true, true));
+        $this->logger->setHandlers([$handler]);
     }
 }
 

--- a/application/controllers/Cron.php
+++ b/application/controllers/Cron.php
@@ -6,7 +6,7 @@ use Monolog\Logger;
 use CANNALInscricoes\Entities\OperadorasEntity;
 use CANNALInscricoes\Entities\RecebiveisEntity;
 use CANNALInscricoes\Entities\OperadorasTransacoesEntity;
-
+ 
 class Cron extends SYS_Controller
 {
     /**

--- a/application/controllers/Teste.php
+++ b/application/controllers/Teste.php
@@ -4,7 +4,10 @@ use CANNALPagamentos\Entities\Cliente;
 use CANNALPagamentos\Entities\Cartao;
 use CANNALPagamentos\Entities\Pedido;
 use CANNALInscricoes\Entities\OperadorasEntity;
-use CANNALLogs\Logs;
+use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\Logger;
 use CANNALInscricoes\Entities\AlunosCreditosEntity;
 
 class Teste extends SYS_Controller
@@ -36,8 +39,15 @@ class Teste extends SYS_Controller
         $this->load->view('teste.html');
         return;
 
-        $log = new Logs('teste\test:sde', 'parac:unde');
-        $log->write('debug', 'teste');
+        $logDir = APPPATH . 'logs/';
+        if (! is_dir($logDir)) {
+            mkdir($logDir, 0777, true);
+        }
+        $logger = new Logger('teste');
+        $handler = new StreamHandler($logDir . 'teste.log', Level::Debug);
+        $handler->setFormatter(new LineFormatter(null, null, true, true));
+        $logger->pushHandler($handler);
+        $logger->debug('teste');
         exit();
 
         $this->load->model('alunos_model');

--- a/application/controllers/Webhook.php
+++ b/application/controllers/Webhook.php
@@ -1,4 +1,8 @@
 <?php
+use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\Logger;
 use CANNALInscricoes\Entities\OperadorasTransacoesEntity;
 
 class Webhook extends SYS_Controller
@@ -41,12 +45,19 @@ class Webhook extends SYS_Controller
         $get  = $this->input->get(NULL, TRUE);
 
         if (! $wh) {
-            $this->logs->setLogDir('Webhook/pagarme');
-            $this->logs->setLogName('webhook_' . date('Y-m-d_H:i:s'));
-            $this->logs->write('DEBUG', 'HEADERS' . PHP_EOL . print_r($headers, true));
-            $this->logs->write('DEBUG', 'POST' . PHP_EOL . print_r($post, true));
-            $this->logs->write('DEBUG', 'GET' . PHP_EOL . print_r($get, true));
-            $this->logs->write('DEBUG', 'INPUT' . PHP_EOL . $payload);
+            $logDir = APPPATH . 'logs/Webhook/pagarme/';
+            if (! is_dir($logDir)) {
+                mkdir($logDir, 0777, true);
+            }
+            $logFile = $logDir . 'webhook_' . date('Y-m-d_H:i:s') . '.log';
+            $logger = new Logger('webhook');
+            $handler = new StreamHandler($logFile, Level::Debug);
+            $handler->setFormatter(new LineFormatter(null, null, true, true));
+            $logger->pushHandler($handler);
+            $logger->debug('HEADERS' . PHP_EOL . print_r($headers, true));
+            $logger->debug('POST' . PHP_EOL . print_r($post, true));
+            $logger->debug('GET' . PHP_EOL . print_r($get, true));
+            $logger->debug('INPUT' . PHP_EOL . $payload);
             $wh = json_decode($payload, true);
         }
         

--- a/application/core/SYS_Controller.php
+++ b/application/core/SYS_Controller.php
@@ -1,5 +1,8 @@
 <?php
-use CANNALLogs\Logs;
+use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\Logger;
 use PHPMailer\PHPMailer\PHPMailer;
 
 defined('DIR_IMAGEM_USUARIOS') or define('DIR_IMAGEM_USUARIOS',  '/writable/usuarios/');
@@ -11,6 +14,13 @@ class SYS_Controller extends CI_Controller
 {
 
     public ?array $vars = [];
+
+    /**
+     * Instância padrão do logger.
+     *
+     * @var Logger
+     */
+    protected Logger $logger;
 
     function __construct()
     {
@@ -54,7 +64,11 @@ class SYS_Controller extends CI_Controller
             $html_errors = true;
         }
 
-        $this->logs = new Logs();
+        $this->logger = new Logger('app');
+        $logPath = APPPATH . 'logs/' . date('Y-m-d') . '.log';
+        $handler = new StreamHandler($logPath, Level::Debug);
+        $handler->setFormatter(new LineFormatter(null, null, true, true));
+        $this->logger->pushHandler($handler);
     }
 
     public function initMail()

--- a/application/core/SYS_Exceptions.php
+++ b/application/core/SYS_Exceptions.php
@@ -5,7 +5,10 @@
  * @package    CannalInscricoes
  */
 
-use CANNALLogs\Logs;
+use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\Logger;
 
 /**
  * Class SYS_Exceptions
@@ -15,11 +18,18 @@ use CANNALLogs\Logs;
 class SYS_Exceptions extends CI_Exceptions
 {
     /**
-     * Objeto de log.
+     * Instância do logger de exceptions.
      *
-     * @var Logs|null
+     * @var Logger
      */
-    private ?Logs $logger = null;
+    private Logger $logger;
+
+    /**
+     * Diretório dos logs de exceptions.
+     *
+     * @var string
+     */
+    private string $logDirectory;
 
     /**
      * Construtor da classe.
@@ -27,7 +37,11 @@ class SYS_Exceptions extends CI_Exceptions
     public function __construct()
     {
         parent::__construct();
-        $this->logger = new Logs('exceptions');
+        $this->logDirectory = APPPATH . 'logs/exceptions/';
+        if (! is_dir($this->logDirectory)) {
+            mkdir($this->logDirectory, 0777, true);
+        }
+        $this->logger = new Logger('exceptions');
     }
 
     /**
@@ -45,7 +59,7 @@ class SYS_Exceptions extends CI_Exceptions
         $type = is_int($severity) && isset($this->levels[$severity]) ? $this->levels[$severity] : (string) $severity;
         $timestamp = date('Y.m.d-H:i:s');
         $fileName = $timestamp . '-' . preg_replace('/[^A-Za-z0-9-_.]/', '_', $message) . '.log';
-        $this->logger->setLogName($fileName);
+        $this->setLogFile($fileName);
 
         $vars = $GLOBALS;
         unset($vars['GLOBALS']);
@@ -61,7 +75,7 @@ class SYS_Exceptions extends CI_Exceptions
             '_ENV'      => $_ENV,
             'input'     => file_get_contents('php://input'),
         ];
-        $this->logger->write('ERROR', json_encode($data, JSON_PRETTY_PRINT | JSON_PARTIAL_OUTPUT_ON_ERROR));
+        $this->logger->error(json_encode($data, JSON_PRETTY_PRINT | JSON_PARTIAL_OUTPUT_ON_ERROR));
 
         if (ENVIRONMENT === 'production') {
             $this->sendExceptionMail($type, 'exceptions/' . $fileName);
@@ -91,5 +105,20 @@ class SYS_Exceptions extends CI_Exceptions
         $CI->mail->Body = $body;
         $CI->mail->addAddress(config_item('email_dev'));
         $CI->mail->send();
+    }
+
+    /**
+     * Define o arquivo de log utilizado pela instância do logger.
+     *
+     * @param string $logName Nome do arquivo de log.
+     *
+     * @return void
+     */
+    private function setLogFile(string $logName): void
+    {
+        $path = $this->logDirectory . $logName;
+        $handler = new StreamHandler($path, Level::Debug);
+        $handler->setFormatter(new LineFormatter(null, null, true, true));
+        $this->logger->setHandlers([$handler]);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,15 @@
 {
-	"name" : "ariellcannal/inscricoes",
-	"type" : "project",
-	"homepage" : "https://inscricoes.cannal.com.br",
-	"license" : "MIT",
+        "name" : "ariellcannal/inscricoes",
+        "type" : "project",
+        "description" : "Aplicação de inscrições com logging via Monolog",
+        "homepage" : "https://inscricoes.cannal.com.br",
+        "license" : "MIT",
 	"require" : {
 		"php" : ">=8.0.0",
 		"dompdf/dompdf" : "~2.0",
-		"phpmailer/phpmailer" : "~6.9",
-		"ariellcannal/pagamentos" : "master",
-		"ariellcannal/logs" : "master"
+                "phpmailer/phpmailer" : "~6.9",
+                "ariellcannal/pagamentos" : "master",
+                "monolog/monolog" : "^3.5"
 	},
 	"require-dev" : {
 		"phpseclib/phpseclib" : "~3.0"
@@ -17,20 +18,16 @@
 			"type" : "git",
 			"url" : "git@github.com:ariellcannal/pagamentos.git",
 			"name" : "pagamentos"
-		}, {
-			"type" : "git",
-			"url" : "git@github.com:ariellcannal/logs.git",
-			"name" : "logs"
-		}
-	],
+                }
+        ],
 	"autoload" : {
-		"psr-4" : {
-			"CANNALInscricoes\\Entities\\" : "application/entities/"
-		}
-	},
+                "psr-4" : {
+                "CANNALInscricoes\\Entities\\" : "application/entities/"
+                }
+        },
 	"minimum-stability" : "dev",
 	"prefer-stable" : true,
-	"config" : {
-		"notify-on-install" : false
-	}
+        "config" : {
+                "notify-on-install" : false
+        }
 }


### PR DESCRIPTION
## Descrição
- remove biblioteca local de logs e ajusta autoload
- integra Monolog diretamente em controladores e no núcleo da aplicação

## Testes
- `php -l application/controllers/Cron.php`
- `php -l application/controllers/Teste.php`
- `php -l application/controllers/Webhook.php`
- `php -l application/core/SYS_Controller.php`
- `php -l application/core/SYS_Exceptions.php`
- `composer dump-autoload` *(falhou: Could not scan for classes inside vendor/dompdf/dompdf/lib)*
- `composer update --ignore-platform-reqs` *(falhou: solicita token GitHub para repositório privado)*
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_e_68b6fbb504f0832a8a4aeaa428272987